### PR TITLE
Align TCK package name with Jakarta TCK process requirement

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/EntityTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/EntityTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package jakarta.data.tck;
+package ee.jakarta.tck.data;
 
 /**
  * Test sample

--- a/tck/src/main/java/ee/jakarta/tck/data/package-info.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) Otavio Santana and others
+ * Copyright (c) 2022 Otavio Santana and others
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-package jakarta.data.tck;
+package ee.jakarta.tck.data;


### PR DESCRIPTION
Here's a minor update to align with the [Jakarta TCK process](https://jakarta.ee/committees/specification/tckprocess/) requirement to avoid having TCK classes in a jakarta.* package,

> TCK tests must not be packaged in the jakarta.* namespace. At the current time TCKs may be packaged in any other namespace, however, the namespace format of ee.jakarta.tck.<spec-name> is recommended.